### PR TITLE
fix jq filter grammar mistake in line 214

### DIFF
--- a/webhooks.sh
+++ b/webhooks.sh
@@ -211,7 +211,7 @@ if [[ $( echo $DATA_SOURCD | jq '.push_data | has("tag")' ) == 'true' && $( echo
 
             echo "镜像未改变，添加注释进行滚动升级"
  
-            kubectl -n $APP_NS get $APP_WORKLOAD -o json | jq "(.spec.template.spec.containers[] | select(.name==\"$APP_CONTAINER\") | .imagePullPolicy) |= \'Always\' " | \
+            kubectl -n $APP_NS get $APP_WORKLOAD -o json | jq '(.spec.template.spec.containers[] | select(.name=="$APP_CONTAINER") | .imagePullPolicy) |= "Always" ' | \
             jq --arg time $( date -Iseconds ) '.spec.template.metadata.annotations += {"webhooks/updateTimestamp": $time}' | \
             kubectl -n $APP_NS apply -f - 2>&1 | tee $APP_NS-$APP_CONTAINER
 


### PR DESCRIPTION
when `repo_type` is `custom`,it will failed in line 214

`jq "(.spec.template.spec.containers[] | select(.name==\"$APP_CONTAINER\") | .imagePullPolicy) |= \"Always\" " | \`
shoudle be fixed as the following
`jq '(.spec.template.spec.containers[] | select(.name=="$APP_CONTAINER") | .imagePullPolicy) |= "Always" ' | \`